### PR TITLE
chore: update prisma and adapter-libsql packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "hasInstallScript": true,
       "dependencies": {
         "@libsql/client": "^0.3.5",
-        "@prisma/adapter-libsql": "^0.4.0",
-        "@prisma/client": "^5.4.0-dev.47",
+        "@prisma/adapter-libsql": "^0.4.1",
+        "@prisma/client": "5.4.0-dev.61",
         "@remix-run/css-bundle": "^2.0.1",
         "@remix-run/node": "^2.0.1",
         "@remix-run/react": "^2.0.1",
@@ -30,7 +30,7 @@
         "@types/react": "^18.2.23",
         "@types/react-dom": "^18.2.8",
         "eslint": "^8.50.0",
-        "prisma": "^5.3.1",
+        "prisma": "5.4.0-dev.61",
         "tsx": "^3.13.0",
         "typescript": "^5.2.2"
       },
@@ -1780,9 +1780,9 @@
       }
     },
     "node_modules/@prisma/adapter-libsql": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@prisma/adapter-libsql/-/adapter-libsql-0.4.0.tgz",
-      "integrity": "sha512-OC0Ne6hYqUn4RFclcGvlADpYLRAkHl5JWTdbjtA86Xc3yUGR0W6Q+pfEFTK5By1KIcRu+2AeV3piSh5RY9PPCA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-libsql/-/adapter-libsql-0.4.1.tgz",
+      "integrity": "sha512-yaiifJNfOkxMk8V/SbxUH6lAKJkcEP9qFBxFwKcDgCjggI7GAAmL0932h9H4KhREOe859UEmT9eX6mLWTs1hyg==",
       "dependencies": {
         "@prisma/driver-adapter-utils": "0.7.0",
         "async-mutex": "0.4.0"
@@ -1792,12 +1792,12 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "5.4.0-dev.47",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.4.0-dev.47.tgz",
-      "integrity": "sha512-YsK64r2hojkfPSEv2Fu6/V3JFcDH3kfhPUHV8cxwBOEDCwHzhJanXxDNyGoGh+HlUqun8LxRGQYfDg+11Mn2ng==",
+      "version": "5.4.0-dev.61",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.4.0-dev.61.tgz",
+      "integrity": "sha512-L540BP8MqLx3DOcv2UbVVuYWpZMlHYRhKqwNB8gSY7bHsgskONBSAH+fxMagjIoph40SXNpFRQimWLNPGDXffg==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "5.4.0-26.4bf3cce422a49f49c661da32d4016a5be81d28b4"
+        "@prisma/engines-version": "5.4.0-35.147b77a820feb1786449562fdffa0c015193eebc"
       },
       "engines": {
         "node": ">=16.13"
@@ -1820,16 +1820,16 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.3.1.tgz",
-      "integrity": "sha512-6QkILNyfeeN67BNEPEtkgh3Xo2tm6D7V+UhrkBbRHqKw9CTaz/vvTP/ROwYSP/3JT2MtIutZm/EnhxUiuOPVDA==",
+      "version": "5.4.0-dev.61",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.4.0-dev.61.tgz",
+      "integrity": "sha512-aqY4zSo3eAspO/f6YEuRZ6CEY1hEQLNu2lnJts9xHlcPRXojUkNcyzMFF+gDfV5+OJaW9OyGTjwhNxCjbSOogg==",
       "devOptional": true,
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "5.4.0-26.4bf3cce422a49f49c661da32d4016a5be81d28b4",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.4.0-26.4bf3cce422a49f49c661da32d4016a5be81d28b4.tgz",
-      "integrity": "sha512-6yhw/P2lWJOljh3QIkqeBNgLPBLVca08YjKPTyOlQ771vnA3pH+EYpIi2VOb2+3NsIM9zlX1NvFadd4qSbtubA=="
+      "version": "5.4.0-35.147b77a820feb1786449562fdffa0c015193eebc",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.4.0-35.147b77a820feb1786449562fdffa0c015193eebc.tgz",
+      "integrity": "sha512-qPnYvBPUu4qus/hlcLpBoiyDu0wq9EsyPUegDLQTcUs5rhH/lMMbtj2u+eewcDNFf1g2khAKd9oglLsh9XFTug=="
     },
     "node_modules/@remix-run/css-bundle": {
       "version": "2.0.1",
@@ -8817,13 +8817,13 @@
       }
     },
     "node_modules/prisma": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.3.1.tgz",
-      "integrity": "sha512-Wp2msQIlMPHe+5k5Od6xnsI/WNG7UJGgFUJgqv/ygc7kOECZapcSz/iU4NIEzISs3H1W9sFLjAPbg/gOqqtB7A==",
+      "version": "5.4.0-dev.61",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.4.0-dev.61.tgz",
+      "integrity": "sha512-5OYKC0JJ54UFaAHA1R5/rHfvSNgs+iNzhpqSrqHzrp0xDnGMmS3fhLl7ks8cR+NtxM25YzezJpcFKqCGMzQmhQ==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "5.3.1"
+        "@prisma/engines": "5.4.0-dev.61"
       },
       "bin": {
         "prisma": "build/index.js"

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "@libsql/client": "^0.3.5",
-    "@prisma/adapter-libsql": "^0.4.0",
-    "@prisma/client": "^5.4.0-dev.47",
+    "@prisma/adapter-libsql": "^0.4.1",
+    "@prisma/client": "5.4.0-dev.61",
     "@remix-run/css-bundle": "^2.0.1",
     "@remix-run/node": "^2.0.1",
     "@remix-run/react": "^2.0.1",
@@ -34,7 +34,7 @@
     "@types/react": "^18.2.23",
     "@types/react-dom": "^18.2.8",
     "eslint": "^8.50.0",
-    "prisma": "^5.3.1",
+    "prisma": "5.4.0-dev.61",
     "tsx": "^3.13.0",
     "typescript": "^5.2.2"
   },


### PR DESCRIPTION
* Update prisma and adapter-libsql packages
* Make `prisma` and `@prisma/client` versions exact (using `^` with dev versions is dangerous and can pick up random integration versions).